### PR TITLE
Fix bugs when running Slicer 4.6 and VTK > 5

### DIFF
--- a/SegmentCAD/SegmentCAD.py
+++ b/SegmentCAD/SegmentCAD.py
@@ -173,7 +173,7 @@ class SegmentCADWidget:
     self.enableLabel.checked = True
     self.enableLabel.setToolTip('Select and identify a custom label map node to define an ROI over the input volumes for faster segmentation.')
     self.inputSelectorLabel = slicer.qMRMLNodeComboBox(self.selectionsCollapsibleButton)
-    self.inputSelectorLabel.nodeTypes = ( ("vtkMRMLLabelMapVolumeNode"), "" )
+    self.inputSelectorLabel.nodeTypes = ["vtkMRMLLabelMapVolumeNode"]
     self.inputSelectorLabel.selectNodeUponCreation = False
     self.inputSelectorLabel.renameEnabled = True
     self.inputSelectorLabel.removeEnabled = False
@@ -193,7 +193,7 @@ class SegmentCADWidget:
     self.outputLabel = qt.QLabel("Output SegmentCAD Label Map", self.outlabelCollapsibleButton)
     self.outputLabel.setToolTip('Select or create a label map volume node as the SegmentCAD segmentation output.')
     self.outputSelectorLabel = slicer.qMRMLNodeComboBox(self.outlabelCollapsibleButton)
-    self.outputSelectorLabel.nodeTypes = ( ("vtkMRMLLabelMapVolumeNode"), "" )
+    self.outputSelectorLabel.nodeTypes = ["vtkMRMLLabelMapVolumeNode"]
     self.outputSelectorLabel.baseName = "SegmentCAD Label Map"
     self.outputSelectorLabel.selectNodeUponCreation = True
     self.outputSelectorLabel.renameEnabled = True

--- a/SegmentCAD/SegmentCADLogic/SegmentCADLogic.py
+++ b/SegmentCAD/SegmentCADLogic/SegmentCADLogic.py
@@ -22,7 +22,7 @@ class SegmentCADLogic:
     if vtk.VTK_MAJOR_VERSION <= 5:
       extract.SetInput(self.multiVolumeNode.GetImageData())
     else:
-      extract.SetInputData(self.multiVolumeNode.GetImageData)
+      extract.SetInputData(self.multiVolumeNode.GetImageData())
     extract.SetComponents(0)
     extract.Update()
     ras2ijk = vtk.vtkMatrix4x4()


### PR DESCRIPTION
Solves issue #5 .
Currently on version 4.6 the Segment CAD extension doesn't run because there are incorrect definitions of single-element Qt string in SegmentCAD.py and there is a missing pair of () in SegmentCADLogic.py